### PR TITLE
Fix LocatorManager

### DIFF
--- a/core/src/main/java/com/crowdar/core/LocatorManager.java
+++ b/core/src/main/java/com/crowdar/core/LocatorManager.java
@@ -14,7 +14,7 @@ public class LocatorManager {
 
     public static By getLocator(String locatorElement, String ... locatorReplacementArgs) {
         try {
-            String[] locatorProperty = locatorElement.split(":");
+            String[] locatorProperty = locatorElement.split(":", 2);
             return getLocatorInEnum(locatorProperty, locatorReplacementArgs);
         } catch (NullPointerException e){
             Logger.getLogger(LocatorManager.class).error(e.getMessage());


### PR DESCRIPTION
Este cambio evita que falle al usarse locators del tipo XPATH que contengan más de un ":" en su estructura. Por ejemplo al llamar ancestor, parents, o childs